### PR TITLE
feat: 添加 Glycoprotein IPC 支持

### DIFF
--- a/StickyHomeworks2/App.xaml.cs
+++ b/StickyHomeworks2/App.xaml.cs
@@ -74,6 +74,8 @@ public partial class App : AppEx
                 services.AddSingleton<ImageService>();
                 services.AddSingleton<ClassIslandIpcService>();
                 services.AddHostedService(sp => sp.GetRequiredService<ClassIslandIpcService>());
+                services.AddSingleton<GlycoproteinIpcService>();
+                services.AddHostedService(sp => sp.GetRequiredService<GlycoproteinIpcService>());
                 services.AddSingleton<AppLogService>();
                 services.AddSingleton<ILoggerProvider, AppLoggerProvider>();
                 services.AddSingleton<ILoggerProvider, FileLoggerProvider>();

--- a/StickyHomeworks2/MainWindow.xaml
+++ b/StickyHomeworks2/MainWindow.xaml
@@ -18,6 +18,7 @@
         TextElement.FontSize="14"
         FontFamily="{StaticResource HarmonyOsSans}"
         Title="{Binding SettingsService.Settings.Title, Mode=OneWay}" 
+        Topmost="{Binding SettingsService.Settings.IsMainWindowTopmost, Mode=OneWay}"
         ShowInTaskbar="{Binding SettingsService.Settings.IsDebugShowInTaskBar}"
         d:DataContext="{d:DesignInstance local:MainWindow}"
         Closing="MainWindow_OnClosing"

--- a/StickyHomeworks2/MainWindow.xaml.cs
+++ b/StickyHomeworks2/MainWindow.xaml.cs
@@ -217,7 +217,7 @@ public partial class MainWindow : Window
         _logger.LogTrace("退出编辑模式: Hard={Hard}", hard);
     }
 
-    private void SetPos()
+    public void SetPos()
     {
         GetCurrentDpi(out var dpi, out _);
         Left = SettingsService.Settings.WindowX / dpi;

--- a/StickyHomeworks2/Models/Settings.cs
+++ b/StickyHomeworks2/Models/Settings.cs
@@ -53,6 +53,8 @@ public class Settings : ObservableRecipient
     private ObservableCollection<SubjectAction> _classIslandSubjects = new();
     private HomeworkTemplateConfig _homeworkTemplate = new();
     private int _updateChannel = 0;
+    private bool _isGlycoproteinEnabled = false;
+    private string _glycoproteinNodeId = "";
 
     public double WindowX
     {
@@ -530,6 +532,43 @@ public class Settings : ObservableRecipient
             _homeworkTemplate = value;
             OnPropertyChanged();
         }
+    }
+
+    #endregion
+
+    #region Glycoprotein
+
+    public bool IsGlycoproteinEnabled
+    {
+        get => _isGlycoproteinEnabled;
+        set
+        {
+            if (value == _isGlycoproteinEnabled) return;
+            _isGlycoproteinEnabled = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>Glycoprotein 节点 ID (Gid), 同时用作本机节点名称。为空时自动生成随机 ID。</summary>
+    public string GlycoproteinNodeId
+    {
+        get => _glycoproteinNodeId;
+        set
+        {
+            if (value == _glycoproteinNodeId) return;
+            _glycoproteinNodeId = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public static string GenerateGlycoproteinNodeId() =>
+        $"stickyHomeworks-{Guid.NewGuid().ToString().Split('-')[1]}";
+
+    /// <summary>确保 Gid 已初始化, 为空时生成随机 ID (仅首次, 之后随设置持久化)。</summary>
+    public void EnsureGlycoproteinNodeId()
+    {
+        if (!string.IsNullOrWhiteSpace(_glycoproteinNodeId)) return;
+        GlycoproteinNodeId = GenerateGlycoproteinNodeId();
     }
 
     #endregion

--- a/StickyHomeworks2/Models/Settings.cs
+++ b/StickyHomeworks2/Models/Settings.cs
@@ -42,6 +42,7 @@ public class Settings : ObservableRecipient
     private bool _autooutwork = true;
     private bool _delayedCleanupEnabled = false;
     private bool _isMainWindowVisible = true;
+    private bool _isMainWindowTopmost = false;
     private bool _isExpiredMarkEnabled = false;
     private bool _debugginginterface = false;
     private Color _expiredMarkColor = Color.FromRgb(0x33, 0x33, 0x33);
@@ -478,6 +479,17 @@ public class Settings : ObservableRecipient
         {
             if (value == _isMainWindowVisible) return;
             _isMainWindowVisible = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsMainWindowTopmost
+    {
+        get => _isMainWindowTopmost;
+        set
+        {
+            if (value == _isMainWindowTopmost) return;
+            _isMainWindowTopmost = value;
             OnPropertyChanged();
         }
     }

--- a/StickyHomeworks2/Services/GlycoproteinIpcService.cs
+++ b/StickyHomeworks2/Services/GlycoproteinIpcService.cs
@@ -1,0 +1,184 @@
+using System.ComponentModel;
+using Glycoprotein;
+using Glycoprotein.Glycosylation;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StickyHomeworks.Models;
+
+namespace StickyHomeworks.Services;
+
+public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
+{
+    public const string HomeworkChangedEventId = "homework.changed";
+
+    private readonly SettingsService _settingsService;
+    private readonly ProfileService _profileService;
+    private readonly ILogger<GlycoproteinIpcService> _logger;
+    private GlycoComplex? _node;
+    private bool _isRunning;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public record PingRespond(string Message);
+
+    public record HomeworkChangedPayload(int HomeworkCount, string Timestamp);
+
+    public GlycoproteinIpcService(SettingsService settingsService, ProfileService profileService, ILogger<GlycoproteinIpcService> logger)
+    {
+        _settingsService = settingsService;
+        _profileService = profileService;
+        _logger = logger;
+        _settingsService.OnSettingsChanged += OnSettingsChanged;
+        _profileService.ProfileSaved += OnProfileSaved;
+    }
+
+    public GlycoComplex? Node => _node;
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        private set
+        {
+            if (value == _isRunning) return;
+            _isRunning = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsRunning)));
+        }
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_settingsService.Settings.IsGlycoproteinEnabled)
+        {
+            _ = StartNodeAsync();
+        }
+        else
+        {
+            _logger.LogInformation("Glycoprotein 服务未启用");
+        }
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await StopNodeAsync();
+        _settingsService.OnSettingsChanged -= OnSettingsChanged;
+        _profileService.ProfileSaved -= OnProfileSaved;
+    }
+
+    private async void OnSettingsChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        try
+        {
+            if (e.PropertyName == nameof(Settings.IsGlycoproteinEnabled))
+            {
+                if (_settingsService.Settings.IsGlycoproteinEnabled)
+                {
+                    await StartNodeAsync();
+                }
+                else
+                {
+                    await StopNodeAsync();
+                }
+            }
+            else if (e.PropertyName == nameof(Settings.GlycoproteinNodeId) && _node != null)
+            {
+                // Gid 变更: 运行中的节点以新 Gid 重建
+                var newId = _settingsService.Settings.GlycoproteinNodeId?.Trim();
+                if (string.IsNullOrWhiteSpace(newId))
+                {
+                    _logger.LogWarning("Glycoprotein 节点 ID 不能为空, 保持当前 Gid [{NodeId}]", _node.Id);
+                    return;
+                }
+                if (newId == _node.Id) return;
+                _logger.LogInformation("Glycoprotein 节点 ID 变更: [{OldNodeId}] → [{NewNodeId}], 正在重建节点", _node.Id, newId);
+                await StopNodeAsync();
+                await StartNodeAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "响应 Glycoprotein 设置变更失败");
+        }
+    }
+
+    public async Task StartNodeAsync()
+    {
+        if (_node != null) return;
+        if (!_settingsService.Settings.IsGlycoproteinEnabled) return;
+        try
+        {
+            var nodeId = _settingsService.Settings.GlycoproteinNodeId?.Trim();
+            if (string.IsNullOrWhiteSpace(nodeId))
+            {
+                _settingsService.Settings.EnsureGlycoproteinNodeId();
+                nodeId = _settingsService.Settings.GlycoproteinNodeId;
+            }
+            var node = new GlycoComplex(nodeId)
+            {
+                Vendor = $"StickyHomeworks2 v{App.AppVersion}"
+            };
+            node.OnDiscovered += beacon =>
+                _logger.LogInformation("发现 Glycoprotein 节点: [{NodeId}] Vendor=[{Vendor}] 字段数: {Count}",
+                    beacon.Id, beacon.Vendor, beacon.Fields.Count);
+            node.OnChanged += beacon =>
+                _logger.LogTrace("Glycoprotein 节点变更: [{NodeId}] 字段数: {Count}", beacon.Id, beacon.Fields.Count);
+            node.OnExpired += beacon =>
+                _logger.LogInformation("Glycoprotein 节点过期: [{NodeId}]", beacon.Id);
+
+            node.AddFunction(new Field.Method {
+                Id = "ping",
+                FriendlyName = "Ping",
+                Description = "测试连通性"
+            }, () => {
+                _logger.LogInformation("收到 Glycoprotein ping 请求");
+                return new PingRespond("Pong!");
+            });
+
+            node.AddEvent(new Field.Event {
+                Id = HomeworkChangedEventId,
+                FriendlyName = "作业数据变更",
+                Description = "作业数据发生变更时广播"
+            });
+
+            _node = node;
+            await node.StartAsync();
+            IsRunning = true;
+            _logger.LogInformation("Glycoprotein 节点已启动, Gid=[{NodeId}]", nodeId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "启动 Glycoprotein 节点失败");
+            _node?.Dispose();
+            _node = null;
+            IsRunning = false;
+        }
+    }
+
+    public async Task StopNodeAsync()
+    {
+        var node = _node;
+        if (node == null) return;
+        _node = null;
+        IsRunning = false;
+        node.Dispose();
+        await Task.CompletedTask;
+        _logger.LogInformation("Glycoprotein 节点已停止");
+    }
+
+    private async void OnProfileSaved(object? sender, EventArgs e)
+    {
+        var node = _node;
+        if (node == null) return;
+        try
+        {
+            await node.EmitEventAsync(HomeworkChangedEventId, new HomeworkChangedPayload(
+                _profileService.Profile.Homeworks.Count,
+                DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")));
+            _logger.LogInformation("已广播 {EventId} 事件 (作业数: {Count})", HomeworkChangedEventId, _profileService.Profile.Homeworks.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "广播 {EventId} 事件失败", HomeworkChangedEventId);
+        }
+    }
+}

--- a/StickyHomeworks2/Services/GlycoproteinIpcService.cs
+++ b/StickyHomeworks2/Services/GlycoproteinIpcService.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using ElysiaFramework;
 using Glycoprotein;
 using Glycoprotein.Glycosylation;
 using Microsoft.Extensions.Hosting;
@@ -22,6 +24,24 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
     public record PingRespond(string Message);
 
     public record HomeworkChangedPayload(int HomeworkCount, string Timestamp);
+
+    public record WindowPositionArgs(
+        [property:Display(Name = "横坐标", Description = "窗口左上角横坐标 (物理像素)")]double X, 
+        [property:Display(Name = "纵坐标", Description = "窗口左上角纵坐标 (物理像素)")]double Y);
+
+    public record WindowSizeArgs(
+        [property:Display(Name = "宽度", Description = "窗口宽度 (物理像素)")]double Width, 
+        [property:Display(Name = "高度", Description = "窗口高度 (物理像素)")]double Height);
+
+    public record SetTitleArgs(
+        [property:Display(Name = "标题", Description = "目标标题")]string Title);
+
+    public record SetTopmostArgs(
+        [property:Description("置顶")]bool Topmost);
+
+    public record WindowStateResponse(
+        bool Visible, bool Topmost, string Title,
+        double X, double Y, double Width, double Height);
 
     public GlycoproteinIpcService(SettingsService settingsService, ProfileService profileService, ILogger<GlycoproteinIpcService> logger)
     {
@@ -125,6 +145,7 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
             node.OnExpired += beacon =>
                 _logger.LogInformation("Glycoprotein 节点过期: [{NodeId}]", beacon.Id);
 
+            #if DEBUG
             node.AddFunction(new Field.Method {
                 Id = "ping",
                 FriendlyName = "Ping",
@@ -133,7 +154,9 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
                 _logger.LogInformation("收到 Glycoprotein ping 请求");
                 return new PingRespond("Pong!");
             });
-
+            #endif
+            
+            RegisterControlFields(node);
             node.AddEvent(new Field.Event {
                 Id = HomeworkChangedEventId,
                 FriendlyName = "作业数据变更",
@@ -163,6 +186,123 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
         node.Dispose();
         await Task.CompletedTask;
         _logger.LogInformation("Glycoprotein 节点已停止");
+    }
+
+    private void RegisterControlFields(GlycoComplex node)
+    {
+        node.AddAction(new Field.Method {
+            Id = "window.hide",
+            FriendlyName = "隐藏窗口",
+            Description = "隐藏 SH2 主窗口"
+        }, HideMainWindow);
+
+        node.AddAction(new Field.Method {
+            Id = "window.show",
+            FriendlyName = "显示窗口",
+            Description = "显示并激活 SH2 主窗口"
+        }, ShowMainWindow);
+
+        node.AddAction<SetTopmostArgs>(new Field.Method {
+            Id = "window.topmost",
+            FriendlyName = "设置窗口置顶",
+            Description = "true=置顶, false=取消置顶"
+        }, SetTopmost);
+
+        node.AddAction<WindowPositionArgs>(new Field.Method {
+            Id = "window.position",
+            FriendlyName = "设置窗口位置",
+            Description = "按物理像素设置主窗口位置 (与设置中的 WindowX/WindowY 一致)"
+        }, SetWindowPosition);
+
+        node.AddAction<WindowSizeArgs>(new Field.Method {
+            Id = "window.size",
+            FriendlyName = "设置窗口大小",
+            Description = "按物理像素设置主窗口大小 (与设置中的 WindowWidth/WindowHeight 一致)"
+        }, SetWindowSize);
+
+        node.AddAction<SetTitleArgs>(new Field.Method {
+            Id = "window.title",
+            FriendlyName = "设置窗口标题",
+            Description = "修改主窗口标题"
+        }, SetWindowTitle);
+
+        node.AddFunction(new Field.Method {
+            Id = "window.getState",
+            FriendlyName = "获取窗口状态",
+            Description = "返回主窗口可见性/置顶/标题/位置大小 (物理像素)"
+        }, GetWindowState);
+    }
+
+    private void HideMainWindow() => RunOnUi(() => {
+        _settingsService.Settings.IsMainWindowVisible = false;
+        AppEx.GetService<MainWindow>().Hide();
+        _logger.LogInformation("Glycoprotein: 已隐藏主窗口");
+    });
+
+    private void ShowMainWindow() => RunOnUi(() => {
+        _settingsService.Settings.IsMainWindowVisible = true;
+        var win = AppEx.GetService<MainWindow>();
+        win.Show();
+        win.Activate();
+        _logger.LogInformation("Glycoprotein: 已显示主窗口");
+    });
+
+    private void SetTopmost(SetTopmostArgs args) => RunOnUi(() => {
+        _settingsService.Settings.IsMainWindowTopmost = args.Topmost;
+        _logger.LogInformation("Glycoprotein: 窗口置顶 = {Topmost}", args.Topmost);
+    });
+
+    private void SetWindowPosition(WindowPositionArgs args) => RunOnUi(() => {
+        var s = _settingsService.Settings;
+        s.WindowX = args.X;
+        s.WindowY = args.Y;
+        AppEx.GetService<MainWindow>().SetPos();
+        _logger.LogInformation("Glycoprotein: 窗口位置 = ({X}, {Y})", args.X, args.Y);
+    });
+
+    private void SetWindowSize(WindowSizeArgs args) => RunOnUi(() => {
+        var s = _settingsService.Settings;
+        s.WindowWidth = args.Width;
+        s.WindowHeight = args.Height;
+        AppEx.GetService<MainWindow>().SetPos();
+        _logger.LogInformation("Glycoprotein: 窗口大小 = {Width}x{Height}", args.Width, args.Height);
+    });
+
+    private void SetWindowTitle(SetTitleArgs args) => RunOnUi(() => {
+        _settingsService.Settings.Title = args.Title;
+        _logger.LogInformation("Glycoprotein: 窗口标题 = [{Title}]", args.Title);
+    });
+
+    private WindowStateResponse GetWindowState() {
+        var s = _settingsService.Settings;
+        var (visible, topmost) = RunOnUi(() => {
+            var win = AppEx.GetService<MainWindow>();
+            return (win.IsVisible, win.Topmost);
+        });
+        return new WindowStateResponse(visible, topmost, s.Title, s.WindowX, s.WindowY, s.WindowWidth, s.WindowHeight);
+    }
+
+    private static void RunOnUi(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            dispatcher.Invoke(action);
+        }
+    }
+
+    private static T RunOnUi<T>(Func<T> func)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            return func();
+        }
+        return dispatcher.Invoke(func);
     }
 
     private async void OnProfileSaved(object? sender, EventArgs e)

--- a/StickyHomeworks2/Services/GlycoproteinIpcService.cs
+++ b/StickyHomeworks2/Services/GlycoproteinIpcService.cs
@@ -6,6 +6,7 @@ using Glycoprotein.Glycosylation;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using StickyHomeworks.Models;
+using StickyHomeworks2.Services;
 
 namespace StickyHomeworks.Services;
 
@@ -24,24 +25,6 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
     public record PingRespond(string Message);
 
     public record HomeworkChangedPayload(int HomeworkCount, string Timestamp);
-
-    public record WindowPositionArgs(
-        [property:Display(Name = "横坐标", Description = "窗口左上角横坐标 (物理像素)")]double X, 
-        [property:Display(Name = "纵坐标", Description = "窗口左上角纵坐标 (物理像素)")]double Y);
-
-    public record WindowSizeArgs(
-        [property:Display(Name = "宽度", Description = "窗口宽度 (物理像素)")]double Width, 
-        [property:Display(Name = "高度", Description = "窗口高度 (物理像素)")]double Height);
-
-    public record SetTitleArgs(
-        [property:Display(Name = "标题", Description = "目标标题")]string Title);
-
-    public record SetTopmostArgs(
-        [property:Description("置顶")]bool Topmost);
-
-    public record WindowStateResponse(
-        bool Visible, bool Topmost, string Title,
-        double X, double Y, double Width, double Height);
 
     public GlycoproteinIpcService(SettingsService settingsService, ProfileService profileService, ILogger<GlycoproteinIpcService> logger)
     {
@@ -156,7 +139,7 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
             });
             #endif
             
-            RegisterControlFields(node);
+            WindowGlycoActions.Register(node, _settingsService, _logger);
             node.AddEvent(new Field.Event {
                 Id = HomeworkChangedEventId,
                 FriendlyName = "作业数据变更",
@@ -186,123 +169,6 @@ public class GlycoproteinIpcService : IHostedService, INotifyPropertyChanged
         node.Dispose();
         await Task.CompletedTask;
         _logger.LogInformation("Glycoprotein 节点已停止");
-    }
-
-    private void RegisterControlFields(GlycoComplex node)
-    {
-        node.AddAction(new Field.Method {
-            Id = "window.hide",
-            FriendlyName = "隐藏窗口",
-            Description = "隐藏 SH2 主窗口"
-        }, HideMainWindow);
-
-        node.AddAction(new Field.Method {
-            Id = "window.show",
-            FriendlyName = "显示窗口",
-            Description = "显示并激活 SH2 主窗口"
-        }, ShowMainWindow);
-
-        node.AddAction<SetTopmostArgs>(new Field.Method {
-            Id = "window.topmost",
-            FriendlyName = "设置窗口置顶",
-            Description = "true=置顶, false=取消置顶"
-        }, SetTopmost);
-
-        node.AddAction<WindowPositionArgs>(new Field.Method {
-            Id = "window.position",
-            FriendlyName = "设置窗口位置",
-            Description = "按物理像素设置主窗口位置 (与设置中的 WindowX/WindowY 一致)"
-        }, SetWindowPosition);
-
-        node.AddAction<WindowSizeArgs>(new Field.Method {
-            Id = "window.size",
-            FriendlyName = "设置窗口大小",
-            Description = "按物理像素设置主窗口大小 (与设置中的 WindowWidth/WindowHeight 一致)"
-        }, SetWindowSize);
-
-        node.AddAction<SetTitleArgs>(new Field.Method {
-            Id = "window.title",
-            FriendlyName = "设置窗口标题",
-            Description = "修改主窗口标题"
-        }, SetWindowTitle);
-
-        node.AddFunction(new Field.Method {
-            Id = "window.getState",
-            FriendlyName = "获取窗口状态",
-            Description = "返回主窗口可见性/置顶/标题/位置大小 (物理像素)"
-        }, GetWindowState);
-    }
-
-    private void HideMainWindow() => RunOnUi(() => {
-        _settingsService.Settings.IsMainWindowVisible = false;
-        AppEx.GetService<MainWindow>().Hide();
-        _logger.LogInformation("Glycoprotein: 已隐藏主窗口");
-    });
-
-    private void ShowMainWindow() => RunOnUi(() => {
-        _settingsService.Settings.IsMainWindowVisible = true;
-        var win = AppEx.GetService<MainWindow>();
-        win.Show();
-        win.Activate();
-        _logger.LogInformation("Glycoprotein: 已显示主窗口");
-    });
-
-    private void SetTopmost(SetTopmostArgs args) => RunOnUi(() => {
-        _settingsService.Settings.IsMainWindowTopmost = args.Topmost;
-        _logger.LogInformation("Glycoprotein: 窗口置顶 = {Topmost}", args.Topmost);
-    });
-
-    private void SetWindowPosition(WindowPositionArgs args) => RunOnUi(() => {
-        var s = _settingsService.Settings;
-        s.WindowX = args.X;
-        s.WindowY = args.Y;
-        AppEx.GetService<MainWindow>().SetPos();
-        _logger.LogInformation("Glycoprotein: 窗口位置 = ({X}, {Y})", args.X, args.Y);
-    });
-
-    private void SetWindowSize(WindowSizeArgs args) => RunOnUi(() => {
-        var s = _settingsService.Settings;
-        s.WindowWidth = args.Width;
-        s.WindowHeight = args.Height;
-        AppEx.GetService<MainWindow>().SetPos();
-        _logger.LogInformation("Glycoprotein: 窗口大小 = {Width}x{Height}", args.Width, args.Height);
-    });
-
-    private void SetWindowTitle(SetTitleArgs args) => RunOnUi(() => {
-        _settingsService.Settings.Title = args.Title;
-        _logger.LogInformation("Glycoprotein: 窗口标题 = [{Title}]", args.Title);
-    });
-
-    private WindowStateResponse GetWindowState() {
-        var s = _settingsService.Settings;
-        var (visible, topmost) = RunOnUi(() => {
-            var win = AppEx.GetService<MainWindow>();
-            return (win.IsVisible, win.Topmost);
-        });
-        return new WindowStateResponse(visible, topmost, s.Title, s.WindowX, s.WindowY, s.WindowWidth, s.WindowHeight);
-    }
-
-    private static void RunOnUi(Action action)
-    {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess())
-        {
-            action();
-        }
-        else
-        {
-            dispatcher.Invoke(action);
-        }
-    }
-
-    private static T RunOnUi<T>(Func<T> func)
-    {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess())
-        {
-            return func();
-        }
-        return dispatcher.Invoke(func);
     }
 
     private async void OnProfileSaved(object? sender, EventArgs e)

--- a/StickyHomeworks2/Services/SettingsService.cs
+++ b/StickyHomeworks2/Services/SettingsService.cs
@@ -22,6 +22,7 @@ public class SettingsService : ObservableRecipient, IHostedService
         SubscribeSettings();
         LoadSettings();
         OnSettingsChanged += OnOnSettingsChanged;
+        Settings.EnsureGlycoproteinNodeId();
     }
 
     private void OnOnSettingsChanged(object? sender, PropertyChangedEventArgs e)

--- a/StickyHomeworks2/Services/WindowGlycoActions.cs
+++ b/StickyHomeworks2/Services/WindowGlycoActions.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using ElysiaFramework;
+using Glycoprotein;
+using Glycoprotein.Glycosylation;
+using Microsoft.Extensions.Logging;
+using StickyHomeworks;
+using StickyHomeworks.Services;
+
+namespace StickyHomeworks2.Services;
+
+public static class WindowGlycoActions {
+
+    public record WindowPositionArgs(
+        [property:Display(Name = "横坐标", Description = "窗口左上角横坐标 (物理像素)")]double X,
+        [property:Display(Name = "纵坐标", Description = "窗口左上角纵坐标 (物理像素)")]double Y);
+
+    public record WindowSizeArgs(
+        [property:Display(Name = "宽度", Description = "窗口宽度 (物理像素)")]double Width,
+        [property:Display(Name = "高度", Description = "窗口高度 (物理像素)")]double Height);
+
+    public record SetTitleArgs(
+        [property:Display(Name = "标题", Description = "目标标题")]string Title);
+
+    public record SetTopmostArgs(
+        [property:Description("置顶")]bool Topmost);
+
+    public record WindowStateResponse(
+        bool Visible, bool Topmost, string Title,
+        double X, double Y, double Width, double Height);
+
+    public static void Register(GlycoComplex node, SettingsService settingsService, ILogger logger) {
+        node.AddAction(new Field.Method {
+            Id = "window.hide",
+            FriendlyName = "隐藏窗口",
+            Description = "隐藏 SH2 主窗口"
+        }, () => HideMainWindow(settingsService, logger));
+
+        node.AddAction(new Field.Method {
+            Id = "window.show",
+            FriendlyName = "显示窗口",
+            Description = "显示并激活 SH2 主窗口"
+        }, () => ShowMainWindow(settingsService, logger));
+
+        node.AddAction<SetTopmostArgs>(new Field.Method {
+            Id = "window.topmost",
+            FriendlyName = "设置窗口置顶",
+            Description = "true=置顶, false=取消置顶"
+        }, args => SetTopmost(args, settingsService, logger));
+
+        node.AddAction<WindowPositionArgs>(new Field.Method {
+            Id = "window.position",
+            FriendlyName = "设置窗口位置",
+            Description = "按物理像素设置主窗口位置 (与设置中的 WindowX/WindowY 一致)"
+        }, args => SetWindowPosition(args, settingsService, logger));
+
+        node.AddAction<WindowSizeArgs>(new Field.Method {
+            Id = "window.size",
+            FriendlyName = "设置窗口大小",
+            Description = "按物理像素设置主窗口大小 (与设置中的 WindowWidth/WindowHeight 一致)"
+        }, args => SetWindowSize(args, settingsService, logger));
+
+        node.AddAction<SetTitleArgs>(new Field.Method {
+            Id = "window.title",
+            FriendlyName = "设置窗口标题",
+            Description = "修改主窗口标题"
+        }, args => SetWindowTitle(args, settingsService, logger));
+
+        node.AddFunction(new Field.Method {
+            Id = "window.getState",
+            FriendlyName = "获取窗口状态",
+            Description = "返回主窗口可见性/置顶/标题/位置大小 (物理像素)"
+        }, () => GetWindowState(settingsService));
+    }
+
+    private static void HideMainWindow(SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        settingsService.Settings.IsMainWindowVisible = false;
+        AppEx.GetService<MainWindow>().Hide();
+        logger.LogInformation("Glycoprotein: 已隐藏主窗口");
+    });
+
+    private static void ShowMainWindow(SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        settingsService.Settings.IsMainWindowVisible = true;
+        var win = AppEx.GetService<MainWindow>();
+        win.Show();
+        win.Activate();
+        logger.LogInformation("Glycoprotein: 已显示主窗口");
+    });
+
+    private static void SetTopmost(SetTopmostArgs args, SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        settingsService.Settings.IsMainWindowTopmost = args.Topmost;
+        logger.LogInformation("Glycoprotein: 窗口置顶 = {Topmost}", args.Topmost);
+    });
+
+    private static void SetWindowPosition(WindowPositionArgs args, SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        var s = settingsService.Settings;
+        s.WindowX = args.X;
+        s.WindowY = args.Y;
+        AppEx.GetService<MainWindow>().SetPos();
+        logger.LogInformation("Glycoprotein: 窗口位置 = ({X}, {Y})", args.X, args.Y);
+    });
+
+    private static void SetWindowSize(WindowSizeArgs args, SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        var s = settingsService.Settings;
+        s.WindowWidth = args.Width;
+        s.WindowHeight = args.Height;
+        AppEx.GetService<MainWindow>().SetPos();
+        logger.LogInformation("Glycoprotein: 窗口大小 = {Width}x{Height}", args.Width, args.Height);
+    });
+
+    private static void SetWindowTitle(SetTitleArgs args, SettingsService settingsService, ILogger logger) => RunOnUi(() => {
+        settingsService.Settings.Title = args.Title;
+        logger.LogInformation("Glycoprotein: 窗口标题 = [{Title}]", args.Title);
+    });
+
+    private static WindowStateResponse GetWindowState(SettingsService settingsService) {
+        var s = settingsService.Settings;
+        var (visible, topmost) = RunOnUi(() => {
+            var win = AppEx.GetService<MainWindow>();
+            return (win.IsVisible, win.Topmost);
+        });
+        return new WindowStateResponse(visible, topmost, s.Title, s.WindowX, s.WindowY, s.WindowWidth, s.WindowHeight);
+    }
+
+    private static void RunOnUi(Action action)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            dispatcher.Invoke(action);
+        }
+    }
+
+    private static T RunOnUi<T>(Func<T> func)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+        {
+            return func();
+        }
+        return dispatcher.Invoke(func);
+    }
+}

--- a/StickyHomeworks2/StickyHomeworks2.csproj
+++ b/StickyHomeworks2/StickyHomeworks2.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <PackageReference Include="ClassIsland.Shared.IPC" Version="2.0.3.1" />
     <PackageReference Include="Emoji.Wpf" Version="0.3.4" />
+    <PackageReference Include="Glycoprotein.Dn8" Version="1.0.0" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageReference Include="Markdig" Version="0.42.0" />
     <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />

--- a/StickyHomeworks2/Views/SettingsWindow.xaml
+++ b/StickyHomeworks2/Views/SettingsWindow.xaml
@@ -1279,8 +1279,8 @@
                         </Grid>
                     </TabItem>
 
-                    <!-- ClassIsland -->
-                    <TabItem Header="CI联动">
+                    <!-- Interaction -->
+                    <TabItem Header="联动">
                         <ScrollViewer>
                             <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
                                 <TextBlock Text="ClassIsland 联动"
@@ -1301,13 +1301,52 @@
 
                                 <ely:SettingsCard IconGlyph="Connection"
                                     Header="连接状态"
-                                    Description="ICP服务活动状态">
+                                    Description="IPC服务活动状态">
                                     <ely:SettingsCard.Switcher>
                                         <TextBlock Text="{Binding ClassIslandIpcService.ConnectionStatus}"
                                             Opacity="0.75" VerticalAlignment="Center"/>
                                     </ely:SettingsCard.Switcher>
                                 </ely:SettingsCard>
 
+                                <TextBlock Text="Glycoprotein 服务"
+                                    Style="{StaticResource MaterialDesignHeadline5TextBlock}"
+                                    Margin="0 24 0 0"/>
+                                <TextBlock Margin="0 8 0 12" Opacity="0.75"
+                                    Text="接入 Glycoprotein 节点网络"/>
+
+                                <ely:SettingsCard IconGlyph="LanConnect"
+                                    Header="启用 Glycoprotein 服务"
+                                    Description="在本机 Glycoprotein 网络中注册 SH2 节点"
+                                    IsOn="{Binding Settings.IsGlycoproteinEnabled, Mode=TwoWay}"/>
+
+                                <ely:SettingsCard IconGlyph="Identifier"
+                                    Header="节点 ID"
+                                    Description="Glycoprotein 节点的唯一标识，修改后立即生效">
+                                    <ely:SettingsCard.Switcher>
+                                        <TextBox MinWidth="100"
+                                                 VerticalAlignment="Center"
+                                                 HorizontalContentAlignment="Right"
+                                                 Text="{Binding Settings.GlycoproteinNodeId}"/>
+                                    </ely:SettingsCard.Switcher>
+                                </ely:SettingsCard>
+
+                                <ely:SettingsCard IconGlyph="Connection"
+                                    Header="节点状态"
+                                    Description="Glycoprotein 节点活动状态">
+                                    <ely:SettingsCard.Switcher>
+                                        <TextBlock Text="{Binding GlycoproteinIpcService.IsRunning}"
+                                            Opacity="0.75" VerticalAlignment="Center"/>
+                                    </ely:SettingsCard.Switcher>
+                                </ely:SettingsCard>
+
+                                <ely:SettingsCard IconGlyph="Lan"
+                                    Header="通信位置"
+                                    Description="本节点 Glycoprotein 核心的通信位置">
+                                    <ely:SettingsCard.Switcher>
+                                        <TextBlock Text="{Binding GlycoSocketDirectory}"
+                                            Opacity="0.75" VerticalAlignment="Center"/>
+                                    </ely:SettingsCard.Switcher>
+                                </ely:SettingsCard>
                                 
                             </StackPanel>
                         </ScrollViewer>

--- a/StickyHomeworks2/Views/SettingsWindow.xaml.cs
+++ b/StickyHomeworks2/Views/SettingsWindow.xaml.cs
@@ -60,7 +60,10 @@ public partial class SettingsWindow : MyWindow
 
     public WallpaperPickingService WallpaperPickingService { get; }
     public ClassIslandIpcService ClassIslandIpcService { get; }
+    public GlycoproteinIpcService GlycoproteinIpcService { get; }
     public EchoCaveService EchoCaveService { get; }
+
+    public string GlycoSocketDirectory => System.IO.Path.Combine(System.IO.Path.GetTempPath(), "glycoprotein");
 
     private readonly SettingsService _settingsService;
     private readonly ILogger<SettingsWindow> _logger;
@@ -88,11 +91,13 @@ public partial class SettingsWindow : MyWindow
     public SettingsWindow(WallpaperPickingService wallpaperPickingService,
         SettingsService settingsService,
         ClassIslandIpcService classIslandIpcService,
+        GlycoproteinIpcService glycoproteinIpcService,
         EchoCaveService echoCaveService,
         ILogger<SettingsWindow> logger)
     {
         WallpaperPickingService = wallpaperPickingService;
         ClassIslandIpcService = classIslandIpcService;
+        GlycoproteinIpcService = glycoproteinIpcService;
         EchoCaveService = echoCaveService;
         _settingsService = settingsService;
         _logger = logger;


### PR DESCRIPTION
> Glycoprotein 是一个用于本地程序交互与服务发现的~~神秘~~ IPC 库

本PR做以下变动:

64a9bbc9c0b8f1ca19cf6317e3d1779123765b2e
- 引入 `Glycoprotein.Dn8` nuget 包
- 新增服务 `GlycoproteinIpcService` 并注入到主机
- 修改设置页 `CI联动` -> `联动` 并添加 Glycoprotein 部分

23a2f644404a9e07166111e5d65b1f25b4d48bf5
- 向 `GlycoproteinIpcService` 服务 添加窗体控制相关 Action 结构域

> 感谢您的审查!